### PR TITLE
Changed data_source to data_dir

### DIFF
--- a/_development.yml
+++ b/_development.yml
@@ -6,4 +6,4 @@ url: http://localhost:4000
 #   serve
 data_url: /fake-data
 
-data_source: /fake-data
+data_dir: /fake-data


### PR DESCRIPTION
Updating `_development.yml` due to this warning after running `make dev`

```
Deprecation: The 'data_source' configuration option has been renamed to 'data_dir'. 
Please update your config file accordingly.
```
